### PR TITLE
Logger support

### DIFF
--- a/example/Main.hs
+++ b/example/Main.hs
@@ -7,6 +7,7 @@ import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import Database.Aerospike
 import Database.Aerospike.Operations
+import Database.Aerospike.Internal.Raw
 
 main :: IO ()
 main = do
@@ -17,6 +18,8 @@ main = do
         binName = "test_bin"
         binStrData = "bin_str_data"
     as <- createAerospikeClient ip 3000
+    setLogCallbackAerospike (\a b c d e -> print (a, b, c, d, e) >> pure True)
+    setLogLevelAerospike AsLogLevelTrace
     conRes <- connectAerospikeClient as
     print conRes
     val <- setStrBin as ns set key binName binStrData 120

--- a/src/Database/Aerospike.hs
+++ b/src/Database/Aerospike.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module Database.Aerospike where
 
@@ -13,13 +14,35 @@ import Database.Aerospike.Internal
 import Database.Aerospike.Internal.Raw
 import Foreign
 import Foreign.C
-import GHC.IO.Handle.Text (memcpy)
+import qualified Foreign.Marshal.Utils as FMU
 import qualified Language.C.Inline as C
-import Text.Printf (printf)
 
-C.context (C.baseCtx <> C.bsCtx <> C.fptrCtx <> asCtx)
+C.context (C.baseCtx <> C.bsCtx <> C.fptrCtx <> C.funCtx <> asCtx)
 C.include "<aerospike/aerospike.h>"
 C.include "<aerospike/aerospike_key.h>"
+C.include "<aerospike/as_log.h>"
+
+{-
+Dirty hack to convert aerospike callback with variadic parameters to haskell callback with char array parameter.
+Needed due to haskell incompatibility with variadic function FFI (even capi need fixed parameter count).
+Haskell FunPtr to log function is stored inside global variable, wrapper C log function is used
+to collect log to char array and call haskell log function.
+-}
+C.verbatim "bool (*as_log_hs_callback)(as_log_level level, const char *func, const char *file, uint32_t line, const char *msg);"
+
+-- Wrapper for variadic function hack
+C.verbatim
+    "bool as_log_hs_callback_wrapper(\n\
+    \    as_log_level level, const char * func, const char * file, uint32_t line,\n\
+    \    const char * fmt, ...)\n\
+    \{\n\
+    \    char msg[1024];\n\
+    \    va_list ap;\n\
+    \    va_start(ap, fmt);\n\
+    \    vsnprintf(msg, 1024, fmt, ap);\n\
+    \    va_end(ap);\n\
+    \    return as_log_hs_callback(level, func, file, line, msg);\n\
+    \}"
 
 createAerospikeClient :: ByteString -> Int -> IO Aerospike
 createAerospikeClient address port' = do
@@ -28,7 +51,7 @@ createAerospikeClient address port' = do
         [C.block| aerospike* {
     as_config config;
     as_config_init(&config);
-    as_config_add_host(&config, $bs-ptr:address, $(int port));
+    as_config_add_host(&config, $bs-cstr:address, $(int port));
     aerospike* as = aerospike_new(&config);
     return as;
     }|]
@@ -42,5 +65,31 @@ connectAerospikeClient (Aerospike as) = alloca @AerospikeError $ \errTmp -> do
         AerospikeOk -> return . Right $ ()
         _ -> Left <$> peek errTmp
 
+-- | Should memory from previous fun pointer be free with C hs_free_fun_ptr or Haskell freeHaskellFunPtr?
+setLogCallbackAerospike :: (AerospikeLogLevel -> ByteString -> ByteString -> Int -> ByteString -> IO Bool) -> IO ()
+setLogCallbackAerospike hsLogFun =
+    [C.block| void {
+    as_log_hs_callback = (bool (*)(as_log_level, const char*, const char*, uint32_t, const char*))($fun-alloc:(bool (*cLogFun)(int, const char*, const char*, uint32_t, const char*)));
+    as_log_set_callback(as_log_hs_callback_wrapper);
+}|]
+  where
+    cLogFun = hsLogFunToC hsLogFun
+
 aerospikeDestroy :: IO (FinalizerPtr Aerospike)
 aerospikeDestroy = [C.exp|void (*aerospike_destroy)(aerospike*) { &aerospike_destroy }|]
+
+setLogLevelAerospike :: AerospikeLogLevel -> IO ()
+setLogLevelAerospike (fromIntegral . fromEnum -> logLevel) = [C.block|void { as_log_set_level($(int logLevel)); }|]
+
+hsLogFunToC :: (AerospikeLogLevel -> ByteString -> ByteString -> Int -> ByteString -> IO Bool) -> (CInt -> CString -> CString -> Word32 -> CString -> IO CBool)
+hsLogFunToC hsLogFun cLogLevel cFunName cFileName cLine cMsg = do
+    funcName <- BS.packCString cFunName
+    fileName <- BS.packCString cFileName
+    msg <- BS.packCString cMsg
+    FMU.fromBool
+        <$> hsLogFun
+            (toEnum . fromIntegral $ cLogLevel)
+            funcName
+            fileName
+            (fromIntegral cLine)
+            msg

--- a/src/Database/Aerospike/Internal.hs
+++ b/src/Database/Aerospike/Internal.hs
@@ -20,4 +20,5 @@ asTypesTable :: Map C.TypeSpecifier TH.TypeQ
 asTypesTable =
   [ (C.TypeName "aerospike", [t|Aerospike|])
   , (C.TypeName "as_error", [t|AerospikeError|])
+  , (C.TypeName "as_log_level", [t|AerospikeLogLevel|])
   ]

--- a/src/Database/Aerospike/Internal/Raw.chs
+++ b/src/Database/Aerospike/Internal/Raw.chs
@@ -14,10 +14,13 @@ import Control.Exception (Exception)
 
 #include <aerospike/aerospike.h>
 #include <aerospike/as_status.h>
+#include <aerospike/as_log.h>
 
 {# context lib="aerospike" #}
 
 {# enum as_status as AerospikeStatus {underscoreToCase} deriving (Eq, Show) #}
+
+{# enum as_log_level as AerospikeLogLevel {underscoreToCase} deriving (Eq, Show) #}
 
 {# pointer *aerospike as Aerospike foreign newtype #}
 


### PR DESCRIPTION
Features:
- Pass haskell logging function to aerospike
Implemented through dirty hack to convert aerospike callback with variadic parameters to haskell callback with char array parameter.
Needed due to haskell incompatibility with variadic function FFI (even capi need fixed parameter count).
Haskell FunPtr to log function is stored inside global variable, wrapper C log function is used to collect log to char array and call haskell log function.

Fixes:
- Disastrous bug caused by using bs-str instead of bs-cstr marshaller. Led to garbage appended to marshalled c strings (bs-str is NOT null-terminated). Seems like Haskell-allocated memory is quite happy with reading out-of-bounds ptr WITHOUT segfault.
- Similar results can be seen by using [alloca](https://hackage.haskell.org/package/base-4.17.0.0/docs/Foreign-Marshal-Alloc.html#v:alloca) (haskell allocator) and reading out-of-bounds ptr.
[malloc/calloc](https://hackage.haskell.org/package/base-4.17.0.0/docs/Foreign-Marshal-Alloc.html#v:malloc) (c allocator) will segfault like in C.